### PR TITLE
Separate requests

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -13,11 +13,18 @@ loader.setup
 before { loader.reload }
 
 get '/' do
-
   response = UseCase::ViewRequests.new(
     google_spreadsheet_gateway: Gateway::GoogleSpreadsheet.new
   ).execute
 
   erb :index, locals: { data: response }
+end
+
+get '/resolved_requests' do
+  response = UseCase::ViewResolvedRequests.new(
+    google_spreadsheet_gateway: Gateway::GoogleSpreadsheet.new
+  ).execute
+
+  erb :resolved_requests, locals: { data: response }
 end
 

--- a/lib/use_case/view_resolved_requests.rb
+++ b/lib/use_case/view_resolved_requests.rb
@@ -1,17 +1,17 @@
 # frozen_string_literal: true
 
-class UseCase::ViewRequests
+class UseCase::ViewResolvedRequests
   def initialize(google_spreadsheet_gateway:)
     @google_spreadsheet_gateway = google_spreadsheet_gateway
   end
 
   def execute
-    condensed_data = []
+    resolved_requests = []
     @google_spreadsheet_gateway.all.each do |row|
-      if row[0] != "" && row[13] == "FALSE"
-        condensed_data << row
+      if row[0] != "" && row[13] == "TRUE"
+        resolved_requests << row
       end
     end
-    condensed_data
+    resolved_requests
   end
 end

--- a/spec/acceptance/requestinator_spec.rb
+++ b/spec/acceptance/requestinator_spec.rb
@@ -1,20 +1,20 @@
-describe 'the schedulinator' do
+describe 'the requestinator' do
   let(:google_spreadsheet_gateway) { Gateway::GoogleSpreadsheet.new }
   let(:view_requests) { UseCase::ViewRequests.new(google_spreadsheet_gateway: google_spreadsheet_gateway) }
   let(:response) { view_requests.execute }
 
   it 'views all delivery teams' do
-    expect(response[1]).to eq(
-      ["16/07/2019 10:48:36",
-      "maysa@madetech.com",
-      "Maysa",
-      "Made Tech",
+    expect(response[1]).to eq([
+      "2019-07-01",
+      "george@madetech.com",
+      "George",
+      "MoJ",
       "Requestinator",
       "2 weeks",
-      "London Bridge",
-      "3",
-      "3",
-      "Ruby",
-      "Software Engineer, Software Engineer, Academy Engineer", "fffh", "FALSE", "FALSE", "FALSE"])
+      "Manchester",
+      "10/10/10",
+      "1",
+      "React",
+      "Software Engineer", "comment", "FALSE", "FALSE", "response"])
   end
 end

--- a/spec/unit/gateway/google_sheets_requests_spec.rb
+++ b/spec/unit/gateway/google_sheets_requests_spec.rb
@@ -4,9 +4,9 @@ describe Gateway::GoogleSpreadsheet do
     context 'viewing the row' do
       it 'can show the request' do
         rows[0].tap do |row|
-          expect(row[0]).to eq('Timestamp')
-          expect(row[1]).to eq('Email address')
-          expect(row[2]).to eq('Requested by')
+          expect(row[0]).to eq('10/07/2019 10:48:36')
+          expect(row[1]).to eq('maysa@madetech.com')
+          expect(row[2]).to eq('Maysa')
         end
       end
     end

--- a/spec/unit/use_case/view_resolved_requests_spec.rb
+++ b/spec/unit/use_case/view_resolved_requests_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe UseCase::ViewResolvedRequests do
+  let(:google_spreadsheet_gateway) { Gateway::GoogleSpreadsheet.new }
+  let(:view_resolved_requests) { described_class.new(google_spreadsheet_gateway: google_spreadsheet_gateway) }
+  let(:response) { view_resolved_requests.execute }
+
+  it 'can show client as the first key for the data' do
+      expect(response[0]).to eq(["10/07/2019 10:48:36",
+        "maysa@madetech.com",
+        "Maysa",
+        "Made Tech",
+        "Requestinator",
+        "2 weeks", "London Bridge", "10/10/10", "1", "Ruby", "Software Engineer",
+        "Project is bulfing stuff", "TRUE", "TRUE", "Yes all good!"])
+  end
+end

--- a/spec/unit/use_case/view_unresolved_requests_spec.rb
+++ b/spec/unit/use_case/view_unresolved_requests_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+describe UseCase::ViewRequests do
+  let(:google_spreadsheet_gateway) { Gateway::GoogleSpreadsheet.new }
+  let(:view_unresolved_requests) { described_class.new(google_spreadsheet_gateway: google_spreadsheet_gateway) }
+  let(:response) { view_unresolved_requests.execute }
+
+  it 'can show client as the first key for the data' do
+      expect(response[1]).to eq(["2019-07-01",
+        "george@madetech.com",
+        "George",
+        "MoJ",
+        "Requestinator",
+        "2 weeks",
+        "Manchester",
+        "10/10/10",
+        "1",
+        "React",
+        "Software Engineer",
+        "comment",
+        "FALSE", "FALSE", "response"])
+  end
+end

--- a/views/index.erb
+++ b/views/index.erb
@@ -96,7 +96,7 @@
           <p>Team size: <%= request[8]%></p>
           <p>Skills required: <%= request[9]%></p>
           <p>Seniority: <%= request[10]%></p>
-          <h2>Additional information</h2>
+          <h2>Project context</h2>
           <p><%= request[11]%></p>
           </div>
         </div>

--- a/views/index.erb
+++ b/views/index.erb
@@ -50,6 +50,10 @@
         <a href="/resolved_requests" class="btn btn-outline-success mb-3" >View resolved requests</a>
       </div>
       <div class="col-md-12">
+        <% if data.empty? %>
+          <h4 class="text-center"> There are no ongoing requests currently </h4>
+        <% end %>
+
         <% data.each do |request| %>
         <div class="row no-gutters border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative">
           <div class="col p-4 d-flex flex-column position-static">
@@ -70,15 +74,15 @@
 
           <p class="mb-1 text-muted text-right" >Submited by: <%=request[1]%></p>
 
-          <% if request[14].nil? %>
+          <% if request[11].empty? %>
             <div hidden class="border border-success rounded mb-3 mt-3">
               <h2 class="text-success text-center">Operations Response</h2>
-              <p class="ml-3 mr-3"><%= request[14]%></p>
+              <p class="ml-3 mr-3"><%= request[11]%></p>
             </div>
           <% else %>
             <div class="border border-success rounded mb-3 mt-3">
               <h2 class="text-success text-center">Operations Response</h2>
-              <p class="ml-3 mr-3"><%= request[14]%></p>
+              <p class="ml-3 mr-3"><%= request[11]%></p>
             </div>
           <% end %>
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -74,18 +74,6 @@
 
           <p class="mb-1 text-muted text-right" >Submited by: <%=request[1]%></p>
 
-          <% if request[11].empty? %>
-            <div hidden class="border border-success rounded mb-3 mt-3">
-              <h2 class="text-success text-center">Operations Response</h2>
-              <p class="ml-3 mr-3"><%= request[11]%></p>
-            </div>
-          <% else %>
-            <div class="border border-success rounded mb-3 mt-3">
-              <h2 class="text-success text-center">Operations Response</h2>
-              <p class="ml-3 mr-3"><%= request[11]%></p>
-            </div>
-          <% end %>
-
           <h2 class="mt-0">Client Information</h2>
           <p>Client: <%= request[3]%></p>
           <p>Client stream: <%= request[4]%></p>

--- a/views/resolved_requests.erb
+++ b/views/resolved_requests.erb
@@ -92,7 +92,7 @@
           <p>Team size: <%= request[8]%></p>
           <p>Skills required: <%= request[9]%></p>
           <p>Seniority: <%= request[10]%></p>
-          <h2>Additional information</h2>
+          <h2>Project context</h2>
           <p><%= request[11]%></p>
           </div>
         </div>

--- a/views/resolved_requests.erb
+++ b/views/resolved_requests.erb
@@ -44,14 +44,14 @@
 
     <main class="container mb-5 mt-5">
       <div class="text-center">
-      <h1> Ongoing Requests</h1>
+        <h1> Resolved Requests</h1>
         <a href="/" class="btn btn-outline-success mb-3" >View ongoing requests</a>
         <a href="https://docs.google.com/forms/d/e/1FAIpQLSfRDAQMB2MzO5Ic7PR8F22H-5TLwh5diYr1tPkq_DxeOSJ2-A/viewform" class="btn btn-outline-success mb-3" >Submit a request</a>
         <a href="/resolved_requests" class="btn btn-outline-success mb-3" >View resolved requests</a>
       </div>
       <div class="col-md-12">
         <% data.each do |request| %>
-        <div class="row no-gutters border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative">
+        <div class="row no-gutters border border-success rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative">
           <div class="col p-4 d-flex flex-column position-static">
           <ul class="progressbar">
             <li class="active">Submited</li>

--- a/views/resolved_requests.erb
+++ b/views/resolved_requests.erb
@@ -70,15 +70,15 @@
 
           <p class="mb-1 text-muted text-right" >Submited by: <%=request[1]%></p>
 
-          <% if request[14].nil? %>
+          <% if request[11].empty? %>
             <div hidden class="border border-success rounded mb-3 mt-3">
               <h2 class="text-success text-center">Operations Response</h2>
-              <p class="ml-3 mr-3"><%= request[14]%></p>
+              <p class="ml-3 mr-3"><%= request[11]%></p>
             </div>
           <% else %>
             <div class="border border-success rounded mb-3 mt-3">
               <h2 class="text-success text-center">Operations Response</h2>
-              <p class="ml-3 mr-3"><%= request[14]%></p>
+              <p class="ml-3 mr-3"><%= request[11]%></p>
             </div>
           <% end %>
 

--- a/views/resolved_requests.erb
+++ b/views/resolved_requests.erb
@@ -70,15 +70,15 @@
 
           <p class="mb-1 text-muted text-right" >Submited by: <%=request[1]%></p>
 
-          <% if request[11].empty? %>
+          <% if request[14].nil? %>
             <div hidden class="border border-success rounded mb-3 mt-3">
               <h2 class="text-success text-center">Operations Response</h2>
-              <p class="ml-3 mr-3"><%= request[11]%></p>
+              <p class="ml-3 mr-3"><%= request[14]%></p>
             </div>
           <% else %>
             <div class="border border-success rounded mb-3 mt-3">
               <h2 class="text-success text-center">Operations Response</h2>
-              <p class="ml-3 mr-3"><%= request[11]%></p>
+              <p class="ml-3 mr-3"><%= request[14]%></p>
             </div>
           <% end %>
 


### PR DESCRIPTION
WHAT: Separated the resolved and unresolved requests onto separate pages.

WHY: To allow easier navigation of requests.