### PR TITLE
Allow comments when request is on going 

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -12,7 +12,6 @@ loader.setup
 
 before { loader.reload }
 
-
 get '/' do
   gateway = Sinatra::Application.environment == :development ? GoogleSheetsSimulator.new : Gateway::GoogleSpreadsheet.new
 
@@ -33,7 +32,7 @@ get '/resolved_requests' do
   erb :resolved_requests, locals: { data: response }
 end
 
-get '/submit_request' do 
+get '/submit_request' do
   erb :submit_request
 end
 

--- a/views/index.erb
+++ b/views/index.erb
@@ -74,6 +74,18 @@
 
           <p class="mb-1 text-muted text-right" >Submited by: <%=request[1]%></p>
 
+          <% if request[14].nil? %>
+            <div hidden class="border border-success rounded mb-3 mt-3">
+              <h2 class="text-success text-center">Operations Response</h2>
+              <p class="ml-3 mr-3"><%= request[14]%></p>
+            </div>
+          <% else %>
+            <div class="border border-success rounded mb-3 mt-3">
+              <h2 class="text-success text-center">Operations Response</h2>
+              <p class="ml-3 mr-3"><%= request[14]%></p>
+            </div>
+          <% end %>
+
           <h2 class="mt-0">Client Information</h2>
           <p>Client: <%= request[3]%></p>
           <p>Client stream: <%= request[4]%></p>


### PR DESCRIPTION
WHAT: Allow comments to be show during in progress stage

WHY: To allow sales to see the progress with comments on a request 