### PR TITLE
Add headings of request summary

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -17,10 +17,14 @@ get '/' do
   gateway = Sinatra::Application.environment == :development ? GoogleSheetsSimulator.new : Gateway::GoogleSpreadsheet.new
 
   response = UseCase::ViewRequests.new(
+    google_spreadsheet_gateway: Gateway::GoogleSpreadsheet.new
+  ).execute
+
+  response_summary = UseCase::ViewRequestsSummary.new(
     google_spreadsheet_gateway: gateway
   ).execute
 
-  erb :index, locals: { data: response }
+  erb :index, locals: { data: response, summary_data: response_summary}
 end
 
 get '/resolved_requests' do
@@ -30,11 +34,13 @@ get '/resolved_requests' do
     google_spreadsheet_gateway: gateway
   ).execute
 
-  erb :resolved_requests, locals: { data: response }
+  response_summary = UseCase::ViewRequestsSummary.new(
+    google_spreadsheet_gateway: gateway
+  ).execute
+
+  erb :resolved_requests, locals: { data: response, summary_data: response_summary}
 end
 
 get '/submit_request' do 
   erb :submit_request
 end
-
-

--- a/lib/use_case/view_requests_summary.rb
+++ b/lib/use_case/view_requests_summary.rb
@@ -1,0 +1,22 @@
+
+class UseCase::ViewRequestsSummary
+  def initialize(google_spreadsheet_gateway:)
+    @google_spreadsheet_gateway = google_spreadsheet_gateway
+  end
+
+  def execute
+    condensed_data = {
+      active:0,
+      in_progress:0
+    }
+    @google_spreadsheet_gateway.all.each do |row|
+      if row[0] != "" && row[13] == "FALSE"
+        condensed_data[:active]+=1
+      end
+      if row[0] != "" && row[12] == "TRUE" && row[13] == "FALSE"
+        condensed_data[:in_progress]+=1
+      end
+    end
+    condensed_data
+  end
+end

--- a/views/index.erb
+++ b/views/index.erb
@@ -43,6 +43,19 @@
     <div class="jumbotron jumbotron-skinny"></div>
 
     <main class="container mb-5 mt-5">
+      <div class="row text-center">
+        <div class="col-sm-6">
+          <h5 class="text-success">Total Pending Requests</h5>
+          <h4 class="text-success"><%= summary_data[:active] %></h4>
+        </div>
+        <div class="col-sm-6">
+          <h5 class="text-success">Requests in Progress</h5>
+          <h4 class="text-success"><%=summary_data[:in_progress] %></h4>
+        </div>
+      </div>
+      <br>
+      <br>
+      <br>
       <div class="text-center">
       <h1> Ongoing Requests</h1>
         <a href="/" class="btn btn-outline-success mb-3" >View ongoing requests</a>

--- a/views/index.erb
+++ b/views/index.erb
@@ -44,18 +44,15 @@
 
     <main class="container mb-5 mt-5">
       <div class="row text-center">
-        <div class="col-sm-6">
-          <h5 class="text-success">Total Pending Requests</h5>
+        <div class="col-sm-6 mb-5">
+          <h5 class="text-success">Total Submitted Requests</h5>
           <h4 class="text-success"><%= summary_data[:active] %></h4>
         </div>
-        <div class="col-sm-6">
+        <div class="col-sm-6 mb-5">
           <h5 class="text-success">Requests in Progress</h5>
           <h4 class="text-success"><%=summary_data[:in_progress] %></h4>
         </div>
       </div>
-      <br>
-      <br>
-      <br>
       <div class="text-center">
       <h1> Ongoing Requests</h1>
         <a href="/" class="btn btn-outline-success mb-3" >View ongoing requests</a>

--- a/views/resolved_requests.erb
+++ b/views/resolved_requests.erb
@@ -44,18 +44,15 @@
 
     <main class="container mb-5 mt-5">
       <div class="row text-center">
-          <div class="col-sm-6">
-            <h5 class="text-success">Total Pending Requests</h5>
-            <h4 class="text-success"><%= summary_data[:active] %></h4>
-          </div>
-          <div class="col-sm-6">
-            <h5 class="text-success">Requests in Progress</h5>
-            <h4 class="text-success"><%=summary_data[:in_progress] %></h4>
-          </div>
+        <div class="col-sm-6 mb-5">
+          <h5 class="text-success">Total Submitted Requests</h5>
+          <h4 class="text-success"><%= summary_data[:active] %></h4>
         </div>
-        <br>
-        <br>
-        <br>
+        <div class="col-sm-6 mb-5">
+          <h5 class="text-success">Requests in Progress</h5>
+          <h4 class="text-success"><%=summary_data[:in_progress] %></h4>
+        </div>
+      </div>
       <div class="text-center">
         <h1> Resolved Requests</h1>
         <a href="/" class="btn btn-outline-success mb-3" >View ongoing requests</a>

--- a/views/resolved_requests.erb
+++ b/views/resolved_requests.erb
@@ -43,6 +43,19 @@
     <div class="jumbotron jumbotron-skinny"></div>
 
     <main class="container mb-5 mt-5">
+      <div class="row text-center">
+          <div class="col-sm-6">
+            <h5 class="text-success">Total Pending Requests</h5>
+            <h4 class="text-success"><%= summary_data[:active] %></h4>
+          </div>
+          <div class="col-sm-6">
+            <h5 class="text-success">Requests in Progress</h5>
+            <h4 class="text-success"><%=summary_data[:in_progress] %></h4>
+          </div>
+        </div>
+        <br>
+        <br>
+        <br>
       <div class="text-center">
         <h1> Resolved Requests</h1>
         <a href="/" class="btn btn-outline-success mb-3" >View ongoing requests</a>


### PR DESCRIPTION
**What?**

- Add summary data of the requests as headers

**Why?**

- To give sales and operation an idea of workload and resources 

![image](https://user-images.githubusercontent.com/46002877/61700705-dd0c8280-ad34-11e9-8129-d066b736d8b7.png)
